### PR TITLE
Fix database profile for libraries unit tests

### DIFF
--- a/codjo-pom-library/pom.xml
+++ b/codjo-pom-library/pom.xml
@@ -54,6 +54,20 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>net.codjo.maven.mojo</groupId>
+                <artifactId>maven-profile-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <configuration>
+                            <databaseType>sybase</databaseType>
+                        </configuration>
+                        <goals>
+                            <goal>database-type</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <dependencies>


### PR DESCRIPTION
## Context

During the last framework release, we unsuccesfully refactored the database profile management. 
## Description

Database profile configuration has been removed from pom-library.
Configuration has been restored.
