### PR TITLE
For release 2.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1292,34 +1292,34 @@
             <dependency>
                 <groupId>net.codjo.control</groupId>
                 <artifactId>codjo-control-common</artifactId>
-                <version>3.52</version>
+                <version>3.53-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.control</groupId>
                 <artifactId>codjo-control-common</artifactId>
-                <version>3.52</version>
+                <version>3.53-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.control</groupId>
                 <artifactId>codjo-control-gui</artifactId>
-                <version>3.52</version>
+                <version>3.53-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.control</groupId>
                 <artifactId>codjo-control-gui</artifactId>
-                <version>3.52</version>
+                <version>3.53-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.control</groupId>
                 <artifactId>codjo-control-server</artifactId>
-                <version>3.52</version>
+                <version>3.53-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.control</groupId>
                 <artifactId>codjo-control-server</artifactId>
-                <version>3.52</version>
+                <version>3.53-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1829,15 +1829,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <extensions>
-            <!-- Version Hackee pour gerer le proxy d'entreprise -->
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-webdav</artifactId>
-                <version>1.0-beta-2-toolkit</version>
-            </extension>
-        </extensions>
-
     </build>
 
     <!--
@@ -1917,13 +1908,14 @@
             <id>external-deployment</id>
             <activation>
                 <property>
-                    <name>external</name>
+                    <name>remote</name>
+                    <value>codjo</value>
                 </property>
             </activation>
             <distributionManagement>
                 <repository>
                     <id>codjo-binary-repository</id>
-                    <url>http://repo.codjo.net/maven2/inhouse</url>
+                    <url>dav:http://repo.codjo.net/maven2/inhouse</url>
                 </repository>
                 <snapshotRepository>
                     <id>codjo-binary-repository</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <!-- POM's layout - http://www.javaworld.com/javaworld/jw-05-2006/jw-0529-maven.html -->
 
     <modelVersion>4.0.0</modelVersion>
@@ -1022,40 +1021,40 @@
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-common</artifactId>
-                <version>0.62</version>
+                <version>0.63-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-common</artifactId>
                 <classifier>tests</classifier>
-                <version>0.62</version>
+                <version>0.63-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-server</artifactId>
-                <version>0.62</version>
+                <version>0.63-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-server</artifactId>
-                <version>0.62</version>
+                <version>0.63-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-server</artifactId>
-                <version>0.62</version>
+                <version>0.63-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-client</artifactId>
-                <version>0.62</version>
+                <version>0.63-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-gui</artifactId>
-                <version>0.62</version>
+                <version>0.63-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.ads</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -902,7 +902,7 @@
             <dependency>
                 <groupId>net.codjo.release-test</groupId>
                 <artifactId>codjo-release-test</artifactId>
-                <version>1.87-SNAPSHOT</version>
+                <version>1.86</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.util</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -902,7 +902,7 @@
             <dependency>
                 <groupId>net.codjo.release-test</groupId>
                 <artifactId>codjo-release-test</artifactId>
-                <version>1.86</version>
+                <version>1.87-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.util</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1831,13 +1831,11 @@
         </pluginManagement>
         <extensions>
             <!-- Version Hackee pour gerer le proxy d'entreprise -->
-            <!--
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-webdav</artifactId>
                 <version>1.0-beta-2-toolkit</version>
             </extension>
-        -->
         </extensions>
 
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1831,11 +1831,13 @@
         </pluginManagement>
         <extensions>
             <!-- Version Hackee pour gerer le proxy d'entreprise -->
+            <!--
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-webdav</artifactId>
                 <version>1.0-beta-2-toolkit</version>
             </extension>
+        -->
         </extensions>
 
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -976,45 +976,45 @@
             <dependency>
                 <groupId>net.codjo.mad</groupId>
                 <artifactId>codjo-mad-common</artifactId>
-                <version>3.168</version>
+                <version>3.169-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.mad</groupId>
                 <artifactId>codjo-mad-server</artifactId>
-                <version>3.168</version>
+                <version>3.169-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.mad</groupId>
                 <artifactId>codjo-mad-server</artifactId>
-                <version>3.168</version>
+                <version>3.169-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.mad</groupId>
                 <artifactId>codjo-mad-server</artifactId>
-                <version>3.168</version>
+                <version>3.169-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.mad</groupId>
                 <artifactId>codjo-mad-client</artifactId>
-                <version>3.168</version>
+                <version>3.169-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.mad</groupId>
                 <artifactId>codjo-mad-client</artifactId>
-                <version>3.168</version>
+                <version>3.169-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.mad</groupId>
                 <artifactId>codjo-mad-gui</artifactId>
-                <version>3.168</version>
+                <version>3.169-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.mad</groupId>
                 <artifactId>codjo-mad-gui</artifactId>
-                <version>3.168</version>
+                <version>3.169-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -813,13 +813,13 @@
             <dependency>
                 <groupId>net.codjo.gui-toolkit</groupId>
                 <artifactId>codjo-gui-toolkit</artifactId>
-                <version>3.105</version>
+                <version>3.106-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.gui-toolkit</groupId>
                 <artifactId>codjo-gui-toolkit</artifactId>
                 <classifier>tests</classifier>
-                <version>3.105</version>
+                <version>3.106-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.xml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <!-- POM's layout - http://www.javaworld.com/javaworld/jw-05-2006/jw-0529-maven.html -->
 
     <modelVersion>4.0.0</modelVersion>
@@ -1828,6 +1829,15 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <extensions>
+            <!-- Version Hackee pour gerer le proxy d'entreprise -->
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-webdav</artifactId>
+                <version>1.0-beta-2-toolkit</version>
+            </extension>
+        </extensions>
+
     </build>
 
     <!--
@@ -1903,6 +1913,23 @@
                 <module>codjo-pom-agif</module>
             </modules>
         </profile>
+        <profile>
+            <id>external-deployment</id>
+            <activation>
+                <property>
+                    <name>external</name>
+                </property>
+            </activation>
+            <distributionManagement>
+                <repository>
+                    <id>codjo-binary-repository</id>
+                    <url>http://repo.codjo.net/maven2/inhouse</url>
+                </repository>
+                <snapshotRepository>
+                    <id>codjo-binary-repository</id>
+                    <url>dav:http//repo.codjo.net/maven2/inhouse-snapshot</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
     </profiles>
-
 </project>


### PR DESCRIPTION
## Release 2.22
### Description

Thie release contains the following pull requests:
- https://github.com/codjo/codjo-control/pull/7
- https://github.com/codjo/codjo-gui-toolkit/pull/7
- https://github.com/codjo/codjo-mad/pull/8
- https://github.com/codjo/codjo-security/pull/3
## Deployment on codjo repository
### Context

We want to be able to deploy libraries in the codjo repository.
### Description

We added a dedicated maven profile activated by the `remote=codjo` property to specify a new distribution management url.
We added an extension to the maven path on a customised `wagon-webdav` (maven dependency). The customisation fixes the proxy issue (the proxy configuration in settings.xml is not transfered to the webdav plugin).

Deployment on Z:
`mvn clean deploy`

Deployment on repo.codjo.net
`mvn clean deploy -Dremote=codjo`

or 
`mvn release:perform -DconnectionUrl=scm:git:file:///path/to/gitRepo -Darguments="-Dremote=codjo"`
