### PR TITLE
For release 2.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -845,23 +845,23 @@
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-builder</artifactId>
-                <version>2.45-SNAPSHOT</version>
+                <version>2.44</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-server</artifactId>
-                <version>2.45-SNAPSHOT</version>
+                <version>2.44</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-server</artifactId>
                 <classifier>tests</classifier>
-                <version>2.45-SNAPSHOT</version>
+                <version>2.44</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-spy</artifactId>
-                <version>2.45-SNAPSHOT</version>
+                <version>2.44</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.standalone-common</groupId>
@@ -1171,45 +1171,45 @@
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-common</artifactId>
-                <version>6.54-SNAPSHOT</version>
+                <version>6.53</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-common</artifactId>
-                <version>6.54-SNAPSHOT</version>
+                <version>6.53</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-gui</artifactId>
-                <version>6.54-SNAPSHOT</version>
+                <version>6.53</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.54-SNAPSHOT</version>
+                <version>6.53</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.54-SNAPSHOT</version>
+                <version>6.53</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.54-SNAPSHOT</version>
+                <version>6.53</version>
                 <classifier>datagen-selector</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-batch</artifactId>
-                <version>6.54-SNAPSHOT</version>
+                <version>6.53</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-release-test</artifactId>
-                <version>6.54-SNAPSHOT</version>
+                <version>6.53</version>
                 <classifier>tests</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1171,45 +1171,45 @@
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-common</artifactId>
-                <version>6.53</version>
+                <version>6.54-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-common</artifactId>
-                <version>6.53</version>
+                <version>6.54-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-gui</artifactId>
-                <version>6.53</version>
+                <version>6.54-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.53</version>
+                <version>6.54-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.53</version>
+                <version>6.54-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.53</version>
+                <version>6.54-SNAPSHOT</version>
                 <classifier>datagen-selector</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-batch</artifactId>
-                <version>6.53</version>
+                <version>6.54-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-release-test</artifactId>
-                <version>6.53</version>
+                <version>6.54-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -206,11 +206,6 @@
                 <version>1.3</version>
             </dependency>
             <dependency>
-                <groupId>jdbc</groupId>
-                <artifactId>jdbc-stdext</artifactId>
-                <version>2.0</version>
-            </dependency>
-            <dependency>
                 <groupId>velocity</groupId>
                 <artifactId>velocity</artifactId>
                 <version>1.4</version>
@@ -442,11 +437,6 @@
                 <groupId>hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
                 <version>1.7.1</version>
-            </dependency>
-            <dependency>
-                <groupId>ejb</groupId>
-                <artifactId>ejb</artifactId>
-                <version>2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.mockrunner</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -845,23 +845,23 @@
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-builder</artifactId>
-                <version>2.44</version>
+                <version>2.45-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-server</artifactId>
-                <version>2.44</version>
+                <version>2.45-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-server</artifactId>
                 <classifier>tests</classifier>
-                <version>2.44</version>
+                <version>2.45-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-spy</artifactId>
-                <version>2.44</version>
+                <version>2.45-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.standalone-common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -897,7 +897,7 @@
             <dependency>
                 <groupId>net.codjo.util</groupId>
                 <artifactId>codjo-util</artifactId>
-                <version>1.10</version>
+                <version>1.11-SNAPSHOT</version>
             </dependency>
 
             <dependency>
@@ -1011,40 +1011,40 @@
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-common</artifactId>
-                <version>0.64</version>
+                <version>0.65-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-common</artifactId>
                 <classifier>tests</classifier>
-                <version>0.64</version>
+                <version>0.65-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-server</artifactId>
-                <version>0.64</version>
+                <version>0.65-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-server</artifactId>
-                <version>0.64</version>
+                <version>0.65-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-server</artifactId>
-                <version>0.64</version>
+                <version>0.65-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-client</artifactId>
-                <version>0.64</version>
+                <version>0.65-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.security</groupId>
                 <artifactId>codjo-security-gui</artifactId>
-                <version>0.64</version>
+                <version>0.65-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.ads</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1049,12 +1049,12 @@
             <dependency>
                 <groupId>net.codjo.ads</groupId>
                 <artifactId>codjo-ads</artifactId>
-                <version>1.13</version>
+                <version>1.14-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.ads</groupId>
                 <artifactId>codjo-ads</artifactId>
-                <version>1.13</version>
+                <version>1.14-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
 


### PR DESCRIPTION
## Release 2.24
### Description

This release contains the following pull requests:
- https://github.com/codjo/codjo-ads/pull/4
- https://github.com/codjo/codjo-security/pull/5
  https://github.com/codjo/codjo-util/pull/6
## Clean obsolete dependencies
### Context

While working on `codjo-pom` and Nexus, we found dependencies that were declared in super-pom but not on our repository.
### Description

The `jdb-ext` and `ejb` dependencies have been removed from dependency list.
