### PR TITLE
 For release 2.31

### DIFF
--- a/codjo-pom-agif/codjo-pom-library/pom.xml
+++ b/codjo-pom-agif/codjo-pom-library/pom.xml
@@ -77,30 +77,5 @@
                 </executions>
             </plugin>
         </plugins>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.scm</groupId>
-                            <artifactId>maven-scm-provider-git-commons</artifactId>
-                            <version>1.0-agf</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.apache.maven.scm</groupId>
-                            <artifactId>maven-scm-provider-gitexe</artifactId>
-                            <version>1.0-agf</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <pushChanges>false</pushChanges>
-                        <goals>deploy</goals>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -771,17 +771,17 @@
             <dependency>
                 <groupId>net.codjo.administration</groupId>
                 <artifactId>codjo-administration-common</artifactId>
-                <version>0.17-SNAPSHOT</version>
+                <version>0.16</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.administration</groupId>
                 <artifactId>codjo-administration-server</artifactId>
-                <version>0.17-SNAPSHOT</version>
+                <version>0.16</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.administration</groupId>
                 <artifactId>codjo-administration-gui</artifactId>
-                <version>0.17-SNAPSHOT</version>
+                <version>0.16</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -771,17 +771,17 @@
             <dependency>
                 <groupId>net.codjo.administration</groupId>
                 <artifactId>codjo-administration-common</artifactId>
-                <version>0.16</version>
+                <version>0.17-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.administration</groupId>
                 <artifactId>codjo-administration-server</artifactId>
-                <version>0.16</version>
+                <version>0.17-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.administration</groupId>
                 <artifactId>codjo-administration-gui</artifactId>
-                <version>0.16</version>
+                <version>0.17-SNAPSHOT</version>
             </dependency>
 
             <dependency>
@@ -1395,7 +1395,7 @@
             <dependency>
                 <groupId>net.codjo.tools</groupId>
                 <artifactId>codjo-tools-event-recorder</artifactId>
-                <version>2.2</version>
+                <version>2.3-SNAPSHOT</version>
             </dependency>
 
             <dependency>
@@ -1639,7 +1639,7 @@
                     <configuration>
                         <pushChanges>false</pushChanges>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <preparationGoals>clean install</preparationGoals>
+                        <preparationGoals>clean</preparationGoals>
                         <goals>deploy</goals>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
# For release 2.31
- https://github.com/codjo/codjo-tools-event-recorder/pull/1
# Harmonisation of plugin release configs
## Context

The release plugin configuration was not coherent for librairies, depending on their parent pom (external or agif). 
## Description

Now the configuration is done in parent pom and there's no more install during preparation goal for external pom.
