### PR TITLE
For Release 2.36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.ipr
 *.iws
 *.iml
+.idea
 target
 .svn
 APDescription.txt
@@ -8,3 +9,10 @@ MTPs-*.*
 pom.xml.*
 release.properties
 .DS_Store
+*.log
+bin
+.project
+.classpath
+.settings
+module
+*.*~

--- a/codjo-pom-agif/codjo-pom-application/pom.xml
+++ b/codjo-pom-agif/codjo-pom-application/pom.xml
@@ -34,7 +34,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <configuration>
-                        <preparationGoals>clean</preparationGoals>
+                        <preparationGoals>clean install</preparationGoals>
                         <arguments>-Dprocess=integration -Ddatabase=integration -Dserver=integration</arguments>
                         <!-- IL FAUT ABSOLUMENT LAISSER INSTALL -->
                         <goals>install</goals>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <!-- POM's layout - http://www.javaworld.com/javaworld/jw-05-2006/jw-0529-maven.html -->
 
     <modelVersion>4.0.0</modelVersion>
@@ -1727,7 +1726,7 @@
                 <plugin>
                     <groupId>net.codjo.maven.mojo</groupId>
                     <artifactId>maven-database-plugin</artifactId>
-                    <version>1.52</version>
+                    <version>1.53-SNAPSHOT</version>
                     <dependencies>
                         <dependency>
                             <groupId>net.codjo.database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <!-- POM's layout - http://www.javaworld.com/javaworld/jw-05-2006/jw-0529-maven.html -->
 
     <modelVersion>4.0.0</modelVersion>
@@ -895,7 +894,7 @@
             <dependency>
                 <groupId>net.codjo.test</groupId>
                 <artifactId>codjo-test-common</artifactId>
-                <version>3.60</version>
+                <version>3.61-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.release-test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <!-- POM's layout - http://www.javaworld.com/javaworld/jw-05-2006/jw-0529-maven.html -->
 
     <modelVersion>4.0.0</modelVersion>
@@ -400,6 +401,12 @@
                 <version>4.8.1</version>
             </dependency>
             <dependency>
+                <groupId>com.googlecode.junit-ext</groupId>
+                <artifactId>junit-ext</artifactId>
+                <classifier>junit45</classifier>
+                <version>1.0-RC3</version>
+            </dependency>
+            <dependency>
                 <groupId>jfcunit</groupId>
                 <artifactId>jfcunit</artifactId>
                 <version>2.06</version>
@@ -434,9 +441,10 @@
                 <version>2.9.1</version>
             </dependency>
             <dependency>
-                <groupId>hsqldb</groupId>
+                <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
-                <version>1.7.1</version>
+                <version>2.2.8</version>
+                <classifier>${envClassifier}</classifier>
             </dependency>
             <dependency>
                 <groupId>com.mockrunner</groupId>
@@ -1542,9 +1550,9 @@
                 <version>1.0.1</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse</groupId>
-                <artifactId>swt</artifactId>
-                <version>3.7M5</version>
+                <groupId>${swt.groupId}</groupId>
+                <artifactId>${swt.artifactId}</artifactId>
+                <version>3.8</version>
             </dependency>
             <dependency>
                 <groupId>com.moxiecode</groupId>
@@ -1936,6 +1944,87 @@
                     <url>dav:http//repo.codjo.net/maven2/inhouse-snapshot</url>
                 </snapshotRepository>
             </distributionManagement>
+        </profile>
+        <!-- SWT profiles -->
+        <profile>
+            <id>linux_x86</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>x86</arch>
+                </os>
+            </activation>
+            <properties>
+                <swt.groupId>org.eclipse.swt</swt.groupId>
+                <swt.artifactId>org.eclipse.swt.gtk.linux.x86</swt.artifactId>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <!-- Due to swt on unix plateform -->
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                    <version>3.3.0</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>linux_x86_64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <properties>
+                <swt.groupId>org.eclipse.swt</swt.groupId>
+                <swt.artifactId>org.eclipse.swt.gtk.linux.x86_64</swt.artifactId>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <!-- Due to swt on unix plateform -->
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                    <version>3.3.0</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>windows_x86</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                    <arch>x86</arch>
+                </os>
+            </activation>
+            <properties>
+                <swt.groupId>org.eclipse.swt</swt.groupId>
+                <swt.artifactId>org.eclipse.swt.win32.win32.x86</swt.artifactId>
+            </properties>
+        </profile>
+        <profile>
+            <id>windows_x86_64</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <properties>
+                <swt.groupId>org.eclipse.swt</swt.groupId>
+                <swt.artifactId>org.eclipse.swt.win32.win32.x86_64</swt.artifactId>
+            </properties>
+        </profile>
+        <profile>
+            <id>mac</id>
+            <activation>
+                <os>
+                    <name>mac os x</name>
+                </os>
+            </activation>
+            <properties>
+                <swt.groupId>org.eclipse.swt.carbon</swt.groupId>
+                <swt.artifactId>macosx</swt.artifactId>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1472,59 +1472,59 @@
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-api</artifactId>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-api</artifactId>
                 <classifier>tests</classifier>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-hsqldb-api</artifactId>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-mysql-api</artifactId>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-oracle-api</artifactId>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-sybase-api</artifactId>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
             <!-- TODO : partie à supprimer a la fin du decoupage de codjo-database -->
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-common</artifactId>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-sybase</artifactId>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-oracle</artifactId>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-mysql</artifactId>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-hsqldb</artifactId>
-                <version>2.7</version>
+                <version>2.8-SNAPSHOT</version>
             </dependency>
 
             <dependency>
@@ -1725,7 +1725,7 @@
                         <dependency>
                             <groupId>net.codjo.database</groupId>
                             <artifactId>codjo-database-${databaseType}</artifactId>
-                            <version>2.7</version>
+                            <version>2.8-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -1749,7 +1749,7 @@
                         <dependency>
                             <groupId>net.codjo.database</groupId>
                             <artifactId>codjo-database-${databaseType}</artifactId>
-                            <version>2.7</version>
+                            <version>2.8-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -883,13 +883,13 @@
             <dependency>
                 <groupId>net.codjo.datagen</groupId>
                 <artifactId>codjo-datagen</artifactId>
-                <version>2.76</version>
+                <version>2.77-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.datagen</groupId>
                 <artifactId>codjo-datagen</artifactId>
                 <classifier>tests</classifier>
-                <version>2.76</version>
+                <version>2.77-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.test</groupId>
@@ -1744,7 +1744,7 @@
                         <dependency>
                             <groupId>net.codjo.datagen</groupId>
                             <artifactId>codjo-datagen</artifactId>
-                            <version>2.76</version>
+                            <version>2.77-SNAPSHOT</version>
                         </dependency>
                         <dependency>
                             <groupId>net.codjo.database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -910,7 +910,7 @@
             <dependency>
                 <groupId>net.codjo.util</groupId>
                 <artifactId>codjo-util</artifactId>
-                <version>1.11</version>
+                <version>1.12-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1079,40 +1079,40 @@
             <dependency>
                 <groupId>net.codjo.workflow</groupId>
                 <artifactId>codjo-workflow-common</artifactId>
-                <version>1.79</version>
+                <version>1.80-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.workflow</groupId>
                 <artifactId>codjo-workflow-server</artifactId>
-                <version>1.79</version>
+                <version>1.80-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.workflow</groupId>
                 <artifactId>codjo-workflow-server</artifactId>
-                <version>1.79</version>
+                <version>1.80-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.workflow</groupId>
                 <artifactId>codjo-workflow-gui</artifactId>
-                <version>1.79</version>
+                <version>1.80-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.workflow</groupId>
                 <artifactId>codjo-workflow-gui</artifactId>
-                <version>1.79</version>
+                <version>1.80-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.workflow</groupId>
                 <artifactId>codjo-workflow-common</artifactId>
-                <version>1.79</version>
+                <version>1.80-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.workflow</groupId>
                 <artifactId>codjo-workflow-server</artifactId>
-                <version>1.79</version>
+                <version>1.80-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1223,50 +1223,50 @@
             <dependency>
                 <groupId>net.codjo.segmentation</groupId>
                 <artifactId>codjo-segmentation-batch</artifactId>
-                <version>1.74</version>
+                <version>1.75-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.segmentation</groupId>
                 <artifactId>codjo-segmentation-batch</artifactId>
-                <version>1.74</version>
+                <version>1.75-SNAPSHOT</version>
                 <classifier>segmentation</classifier>
                 <type>ksh</type>
             </dependency>
             <dependency>
                 <groupId>net.codjo.segmentation</groupId>
                 <artifactId>codjo-segmentation-common</artifactId>
-                <version>1.74</version>
+                <version>1.75-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.segmentation</groupId>
                 <artifactId>codjo-segmentation-datagen</artifactId>
-                <version>1.74</version>
+                <version>1.75-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.segmentation</groupId>
                 <artifactId>codjo-segmentation-datagen</artifactId>
-                <version>1.74</version>
+                <version>1.75-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.segmentation</groupId>
                 <artifactId>codjo-segmentation-gui</artifactId>
-                <version>1.74</version>
+                <version>1.75-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.segmentation</groupId>
                 <artifactId>codjo-segmentation-server</artifactId>
-                <version>1.74</version>
+                <version>1.75-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.segmentation</groupId>
                 <artifactId>codjo-segmentation-sql</artifactId>
-                <version>1.74</version>
+                <version>1.75-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.segmentation</groupId>
                 <artifactId>codjo-segmentation-sql</artifactId>
-                <version>1.74</version>
+                <version>1.75-SNAPSHOT</version>
                 <classifier>sql</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <!-- POM's layout - http://www.javaworld.com/javaworld/jw-05-2006/jw-0529-maven.html -->
 
     <modelVersion>4.0.0</modelVersion>
@@ -769,6 +770,12 @@
                 <groupId>org.crossbowlabs</groupId>
                 <artifactId>globs</artifactId>
                 <version>1.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>hsqldb</groupId>
+                        <artifactId>hsqldb</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- ***************************************************************************************** -->

--- a/pom.xml
+++ b/pom.xml
@@ -899,7 +899,7 @@
             <dependency>
                 <groupId>net.codjo.release-test</groupId>
                 <artifactId>codjo-release-test</artifactId>
-                <version>1.89</version>
+                <version>1.90-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.util</groupId>
@@ -1834,7 +1834,7 @@
                         <dependency>
                             <groupId>net.codjo.release-test</groupId>
                             <artifactId>codjo-release-test</artifactId>
-                            <version>1.89</version>
+                            <version>1.90-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1130,49 +1130,49 @@
             <dependency>
                 <groupId>net.codjo.imports</groupId>
                 <artifactId>codjo-imports-common</artifactId>
-                <version>3.48</version>
+                <version>3.49-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.imports</groupId>
                 <artifactId>codjo-imports-gui</artifactId>
-                <version>3.48</version>
+                <version>3.49-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.imports</groupId>
                 <artifactId>codjo-imports-server</artifactId>
-                <version>3.48</version>
+                <version>3.49-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.imports</groupId>
                 <artifactId>codjo-imports-server</artifactId>
-                <version>3.48</version>
+                <version>3.49-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.imports</groupId>
                 <artifactId>codjo-imports-batch</artifactId>
-                <version>3.48</version>
+                <version>3.49-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.imports</groupId>
                 <artifactId>codjo-imports-plugin-filter</artifactId>
-                <version>3.48</version>
+                <version>3.49-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.imports</groupId>
                 <artifactId>codjo-imports-plugin-filter-kernel</artifactId>
-                <version>3.48</version>
+                <version>3.49-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.imports</groupId>
                 <artifactId>codjo-imports-plugin-filter-kernel</artifactId>
-                <version>3.48</version>
+                <version>3.49-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.imports</groupId>
                 <artifactId>codjo-imports-plugin-filter-gui</artifactId>
-                <version>3.48</version>
+                <version>3.49-SNAPSHOT</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
# For Release 2.36

codjo-sandbox requests
- Fix linux support issues                                  https://github.com/codjo/codjo-release-test/pull/14
- Add a PathUtil class to commonalise normalize method.     https://github.com/codjo/codjo-util/pull/7
- Fix hsqldb upgrade and CommandFileTest random failure     https://github.com/codjo/codjo-workflow/pull/4
- Fix hsqldb upgrade : groupId has changed                  https://github.com/codjo/codjo-segmentation/pull/5
- Fix hsqldb upgrade issues                                 https://github.com/codjo/codjo-imports/pull/8
- Fix script execution after codjo-database upgrade.        https://github.com/codjo/codjo-datagen/pull/8
- For Release 2.36                                          https://github.com/codjo/codjo-pom/pull/40
- Move PathUtil.normalize method to codjo-util              https://github.com/codjo/codjo-test/pull/8
- Hsqldb Implementation - normalisation                     https://github.com/codjo/codjo-database/pull/8

External requests
- Add a new JUnit Matcher for validating a XML ...          https://github.com/codjo/codjo-test/pull/7
- Bug fixes for Linux                                       https://github.com/codjo/codjo-pom/pull/32
- Bug fixes for Linux                                       https://github.com/codjo/codjo-release-test/pull/13
- Implementation of codjo-database for Hsqldb                   https://github.com/codjo/codjo-database/pull/7
- Bug fixes for Linux                                           https://github.com/codjo/codjo-test/pull/6
# Bug fixes for Linux
## Context

`codjo-release-test` tests doesn't pass under Linux.
## Description

The following tasks has been achieved :
- Upgrade of `hsqldb to 2.2.8` (groupId has changed from hsqldb to org.hsqldb).
- Add `junit-ext` to ignore some tests when a condition is true.
- Declare `SWT` dependencies from the actual platform (OS, cpu architecture) (and upgrade to SWT 3.8). Maven profiles have been added to select the appropriate dependency (including jna for linux)
- Standardization of .gitignore.
### New Artifacts
- hsqldb-2.2.8 for jdk15 and jdk16 must be downloaded from http://repo2.maven.org/maven2/org/hsqldb/hsqldb/2.2.8/
- junit-ext-1.0-RC3-junit45 must be downloaded from http://us3.maven.org:8081/nexus/content/repositories/public/com/googlecode/junit-ext/junit-ext/1.0-RC3/
- SWT 3.8 for the following profiles must be downloaded from https://swt-repo.googlecode.com/svn/repo/org/eclipse/swt/
- SWT 3.8 for windows_x86, windows_x86_64, linux_x86_32, linux_x86_64, cocoa.mac_osx platforms must be downloaded from https://swt-repo.googlecode.com/svn/repo/org/eclipse/swt/org.eclipse.swt.gtk.linux.x86_64/3.8/
- jna-3.3.0 must be downloaded from http://download.java.net/maven/2/net/java/dev/jna/jna/3.3.0/
# Fix application delivery issue
## Context

`release:perform` fails during application's delivery
## Description

Fixed by adding `install` in preparation goal.
