### PR TITLE
For Release 2.36.1

### DIFF
--- a/codjo-pom-agif/codjo-pom-application/pom.xml
+++ b/codjo-pom-agif/codjo-pom-application/pom.xml
@@ -35,7 +35,8 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <configuration>
                         <preparationGoals>clean install</preparationGoals>
-                        <arguments>-Dprocess=integration -Ddatabase=integration -Dserver=integration</arguments>
+                        <arguments>-Ddatabase=integration</arguments>
+                        <releaseProfiles>process-integation,database-integration,server-integration</releaseProfiles>
                         <!-- IL FAUT ABSOLUMENT LAISSER INSTALL -->
                         <goals>install</goals>
                     </configuration>


### PR DESCRIPTION
# For Release 2.36.1
# Fix application delivery issue
## Context

`release:perform` was failing during application's delivery. A fix had been provided by adding `install` in preparation goal.
## Description

That fix implies that the release tests are launched during the `release:prepare` phase making a package for a big application too long.
A new configuration for the `maven-release-plugin` has been set:
- only the database configuration is set within the `arguments` tag,
- other profiles are set in `releaseProfiles` tag.

To be sure that the `release:prepare` is performed on the database integration the argument has to be added in the command line:

`mvn release:prepare -Darguments="-Ddatabase=integration" -Ddatabase=integration`
