### PR TITLE
For Release 2.36.2

### DIFF
--- a/codjo-pom-agif/codjo-pom-application/pom.xml
+++ b/codjo-pom-agif/codjo-pom-application/pom.xml
@@ -36,7 +36,7 @@
                     <configuration>
                         <preparationGoals>clean install</preparationGoals>
                         <arguments>-Ddatabase=integration</arguments>
-                        <releaseProfiles>process-integation,database-integration,server-integration</releaseProfiles>
+                        <releaseProfiles>process-integration,database-integration,server-integration</releaseProfiles>
                         <!-- IL FAUT ABSOLUMENT LAISSER INSTALL -->
                         <goals>install</goals>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1726,7 +1726,7 @@
                 <plugin>
                     <groupId>net.codjo.maven.mojo</groupId>
                     <artifactId>maven-database-plugin</artifactId>
-                    <version>1.53</version>
+                    <version>1.54-SNAPSHOT</version>
                     <dependencies>
                         <dependency>
                             <groupId>net.codjo.database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -905,7 +905,7 @@
             <dependency>
                 <groupId>net.codjo.release-test</groupId>
                 <artifactId>codjo-release-test</artifactId>
-                <version>1.90</version>
+                <version>1.91-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.util</groupId>
@@ -1840,7 +1840,7 @@
                         <dependency>
                             <groupId>net.codjo.release-test</groupId>
                             <artifactId>codjo-release-test</artifactId>
-                            <version>1.90</version>
+                            <version>1.91-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -905,7 +905,7 @@
             <dependency>
                 <groupId>net.codjo.release-test</groupId>
                 <artifactId>codjo-release-test</artifactId>
-                <version>1.91-SNAPSHOT</version>
+                <version>1.90</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.util</groupId>
@@ -1726,7 +1726,7 @@
                 <plugin>
                     <groupId>net.codjo.maven.mojo</groupId>
                     <artifactId>maven-database-plugin</artifactId>
-                    <version>1.54-SNAPSHOT</version>
+                    <version>1.53</version>
                     <dependencies>
                         <dependency>
                             <groupId>net.codjo.database</groupId>
@@ -1840,7 +1840,7 @@
                         <dependency>
                             <groupId>net.codjo.release-test</groupId>
                             <artifactId>codjo-release-test</artifactId>
-                            <version>1.91-SNAPSHOT</version>
+                            <version>1.90</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
# For Release 2.36.2
# Fix application delivery issue
## Context

`release:perform` was failing during application's delivery. A fix had been provided by adding `install` in preparation goal.
## Description

The fix contained in the 2.36.1 fix contains a typin error, this is corrected here.
