### PR TITLE
For release 2.36.3

### DIFF
--- a/codjo-pom-agif/codjo-pom-application/pom.xml
+++ b/codjo-pom-agif/codjo-pom-application/pom.xml
@@ -34,9 +34,8 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <configuration>
-                        <preparationGoals>clean install</preparationGoals>
-                        <arguments>-Ddatabase=integration</arguments>
-                        <releaseProfiles>process-integration,database-integration,server-integration</releaseProfiles>
+                        <preparationGoals>clean</preparationGoals>
+                        <arguments>-Dprocess=integration -Ddatabase=integration -Dserver=integration</arguments>
                         <!-- IL FAUT ABSOLUMENT LAISSER INSTALL -->
                         <goals>install</goals>
                     </configuration>

--- a/codjo-pom-agif/codjo-pom-plugin/pom.xml
+++ b/codjo-pom-agif/codjo-pom-plugin/pom.xml
@@ -100,6 +100,16 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.scm</groupId>
+                <artifactId>maven-scm-provider-git-commons</artifactId>
+                <version>1.0-agf</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.scm</groupId>
+                <artifactId>maven-scm-provider-gitexe</artifactId>
+                <version>1.0-agf</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.scm</groupId>
                 <artifactId>maven-scm-manager-plexus</artifactId>
                 <version>1.1</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -905,7 +905,7 @@
             <dependency>
                 <groupId>net.codjo.release-test</groupId>
                 <artifactId>codjo-release-test</artifactId>
-                <version>1.90</version>
+                <version>1.91-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.util</groupId>
@@ -1726,7 +1726,7 @@
                 <plugin>
                     <groupId>net.codjo.maven.mojo</groupId>
                     <artifactId>maven-database-plugin</artifactId>
-                    <version>1.53</version>
+                    <version>1.54-SNAPSHOT</version>
                     <dependencies>
                         <dependency>
                             <groupId>net.codjo.database</groupId>
@@ -1840,7 +1840,7 @@
                         <dependency>
                             <groupId>net.codjo.release-test</groupId>
                             <artifactId>codjo-release-test</artifactId>
-                            <version>1.90</version>
+                            <version>1.91-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -905,7 +905,7 @@
             <dependency>
                 <groupId>net.codjo.release-test</groupId>
                 <artifactId>codjo-release-test</artifactId>
-                <version>1.91-SNAPSHOT</version>
+                <version>1.90</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.util</groupId>
@@ -1726,7 +1726,7 @@
                 <plugin>
                     <groupId>net.codjo.maven.mojo</groupId>
                     <artifactId>maven-database-plugin</artifactId>
-                    <version>1.54-SNAPSHOT</version>
+                    <version>1.53</version>
                     <dependencies>
                         <dependency>
                             <groupId>net.codjo.database</groupId>
@@ -1840,7 +1840,7 @@
                         <dependency>
                             <groupId>net.codjo.release-test</groupId>
                             <artifactId>codjo-release-test</artifactId>
-                            <version>1.91-SNAPSHOT</version>
+                            <version>1.90</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
# For Release 2.36.3
# Rollback 'Fix application delivery issue'
## Context

`release:perform` was failing during application's delivery. 
     We tryed to solve this issue, but it doesn't work.
## Description

The fix contained in the 2.36.2 is not working, we rollback this modification.
