### PR TITLE
For release 2.37

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -905,7 +905,7 @@
             <dependency>
                 <groupId>net.codjo.release-test</groupId>
                 <artifactId>codjo-release-test</artifactId>
-                <version>1.90</version>
+                <version>1.91-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.util</groupId>
@@ -1726,7 +1726,7 @@
                 <plugin>
                     <groupId>net.codjo.maven.mojo</groupId>
                     <artifactId>maven-database-plugin</artifactId>
-                    <version>1.53</version>
+                    <version>1.54-SNAPSHOT</version>
                     <dependencies>
                         <dependency>
                             <groupId>net.codjo.database</groupId>
@@ -1840,7 +1840,7 @@
                         <dependency>
                             <groupId>net.codjo.release-test</groupId>
                             <artifactId>codjo-release-test</artifactId>
-                            <version>1.90</version>
+                            <version>1.91-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
# For Release 2.37

codjo-sandbox requests
- https://github.com/codjo/codjo-release-test/pull/15

This release contains a new version of the maven-database-plugin (enhance initFromProd goal to allow to execute the sql release script).
