### PR TITLE
For Release 2.41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1745,13 +1745,8 @@
                 <plugin>
                     <groupId>net.codjo.maven.mojo</groupId>
                     <artifactId>maven-datagen-plugin</artifactId>
-                    <version>1.85</version>
+                    <version>1.86-SNAPSHOT</version>
                     <dependencies>
-                        <dependency>
-                            <groupId>net.codjo.datagen</groupId>
-                            <artifactId>codjo-datagen</artifactId>
-                            <version>2.78</version>
-                        </dependency>
                         <dependency>
                             <groupId>net.codjo.database</groupId>
                             <artifactId>codjo-database-${databaseType}</artifactId>
@@ -1836,13 +1831,6 @@
                     <groupId>net.codjo.maven.mojo</groupId>
                     <artifactId>maven-test-release-plugin</artifactId>
                     <version>1.72</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>net.codjo.release-test</groupId>
-                            <artifactId>codjo-release-test</artifactId>
-                            <version>1.91</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1726,7 +1726,7 @@
                 <plugin>
                     <groupId>net.codjo.maven.mojo</groupId>
                     <artifactId>maven-database-plugin</artifactId>
-                    <version>1.54</version>
+                    <version>1.55-SNAPSHOT</version>
                     <dependencies>
                         <dependency>
                             <groupId>net.codjo.database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -858,23 +858,23 @@
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-builder</artifactId>
-                <version>2.45</version>
+                <version>2.46-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-server</artifactId>
-                <version>2.45</version>
+                <version>2.46-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-server</artifactId>
                 <classifier>tests</classifier>
-                <version>2.45</version>
+                <version>2.46-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.sql</groupId>
                 <artifactId>codjo-sql-spy</artifactId>
-                <version>2.45</version>
+                <version>2.46-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.standalone-common</groupId>
@@ -1478,59 +1478,59 @@
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-api</artifactId>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-api</artifactId>
                 <classifier>tests</classifier>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-hsqldb-api</artifactId>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-mysql-api</artifactId>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-oracle-api</artifactId>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-sybase-api</artifactId>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
             <!-- TODO : partie à supprimer a la fin du decoupage de codjo-database -->
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-common</artifactId>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-sybase</artifactId>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-oracle</artifactId>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-mysql</artifactId>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-hsqldb</artifactId>
-                <version>2.8</version>
+                <version>2.9-SNAPSHOT</version>
             </dependency>
 
             <dependency>
@@ -1731,7 +1731,7 @@
                         <dependency>
                             <groupId>net.codjo.database</groupId>
                             <artifactId>codjo-database-${databaseType}</artifactId>
-                            <version>2.8</version>
+                            <version>2.9-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -1755,7 +1755,7 @@
                         <dependency>
                             <groupId>net.codjo.database</groupId>
                             <artifactId>codjo-database-${databaseType}</artifactId>
-                            <version>2.8</version>
+                            <version>2.9-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                     <executions>


### PR DESCRIPTION
## For Release 2.41

codjo-sandbox requests:
- Centralisation of connection's construction and customisation    https://github.com/codjo/codjo-sql/pull/7
- Centralisation of connection's construction and customisation    https://github.com/codjo/codjo-database/pull/9

maven-datagen-plugin, maven-database-plugin have been upgraded
## Remove unnecessary plugin dependencies
### Context

Dependencies have been added to plugin management to avoid switching to snapshot a plugin when its library is switched to snapshot. This was not working.
### Description

A rollback has been done.
