### PR TITLE
For Release 2.42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -903,7 +903,7 @@
             <dependency>
                 <groupId>net.codjo.tokio</groupId>
                 <artifactId>codjo-tokio</artifactId>
-                <version>2.53</version>
+                <version>2.54-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.datagen</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1203,45 +1203,45 @@
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-common</artifactId>
-                <version>6.55</version>
+                <version>6.56-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-common</artifactId>
-                <version>6.55</version>
+                <version>6.56-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-gui</artifactId>
-                <version>6.55</version>
+                <version>6.56-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.55</version>
+                <version>6.56-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.55</version>
+                <version>6.56-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.55</version>
+                <version>6.56-SNAPSHOT</version>
                 <classifier>datagen-selector</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-batch</artifactId>
-                <version>6.55</version>
+                <version>6.56-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-release-test</artifactId>
-                <version>6.55</version>
+                <version>6.56-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -903,7 +903,7 @@
             <dependency>
                 <groupId>net.codjo.tokio</groupId>
                 <artifactId>codjo-tokio</artifactId>
-                <version>2.54-SNAPSHOT</version>
+                <version>2.53</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.datagen</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1497,59 +1497,59 @@
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-api</artifactId>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-api</artifactId>
                 <classifier>tests</classifier>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-hsqldb-api</artifactId>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-mysql-api</artifactId>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-oracle-api</artifactId>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-sybase-api</artifactId>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
             <!-- TODO : partie à supprimer a la fin du decoupage de codjo-database -->
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-common</artifactId>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-sybase</artifactId>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-oracle</artifactId>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-mysql</artifactId>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.database</groupId>
                 <artifactId>codjo-database-hsqldb</artifactId>
-                <version>2.9</version>
+                <version>2.10-SNAPSHOT</version>
             </dependency>
 
             <dependency>
@@ -1745,12 +1745,12 @@
                 <plugin>
                     <groupId>net.codjo.maven.mojo</groupId>
                     <artifactId>maven-database-plugin</artifactId>
-                    <version>1.55</version>
+                    <version>1.56-SNAPSHOT</version>
                     <dependencies>
                         <dependency>
                             <groupId>net.codjo.database</groupId>
                             <artifactId>codjo-database-${databaseType}</artifactId>
-                            <version>2.9</version>
+                            <version>2.10-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -1769,7 +1769,7 @@
                         <dependency>
                             <groupId>net.codjo.database</groupId>
                             <artifactId>codjo-database-${databaseType}</artifactId>
-                            <version>2.9</version>
+                            <version>2.10-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -565,6 +565,11 @@
                 <version>1.4.9</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.wicket</groupId>
+                <artifactId>wicket-auth-roles</artifactId>
+                <version>1.4.9</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.5.8</version>
@@ -580,7 +585,21 @@
                 <artifactId>jetty</artifactId>
                 <version>6.1.3</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.mortbay.jetty</groupId>
+                <artifactId>jetty-naming</artifactId>
+                <version>6.1.26</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mortbay.jetty</groupId>
+                <artifactId>jetty-plus</artifactId>
+                <version>6.1.26</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-dbcp</groupId>
+                <artifactId>commons-dbcp</artifactId>
+                <version>1.3</version>
+            </dependency>
             <dependency>
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>jsp-2.1</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1081,12 +1081,12 @@
             <dependency>
                 <groupId>net.codjo.ads</groupId>
                 <artifactId>codjo-ads</artifactId>
-                <version>1.15</version>
+                <version>1.16-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.ads</groupId>
                 <artifactId>codjo-ads</artifactId>
-                <version>1.15</version>
+                <version>1.16-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
 


### PR DESCRIPTION
## For Release 2.42

codjo-sandbox requests      
- Oracle support - Improve unit test helpers        https://github.com/codjo/codjo-broadcast/pull/7
- Add a TransactionManager      https://github.com/codjo/codjo-database/pull/10
- Passwords changed for test accounts       https://github.com/codjo/codjo-ads/pull/6
## Add jetty wicket and commons-dbcp dependencies
### Context

We need dependencies that were not in super-pom
### Description

The following dependencies have been added :
- jetty-naming
- jetty-plus
- commons-dbcp
- wicket-auth-roles
