### PR TITLE
For release  2.43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1839,7 +1839,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.2</version>
                 </plugin>
                 <plugin>
                     <groupId>net.codjo.maven.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -835,13 +835,13 @@
             <dependency>
                 <groupId>net.codjo.gui-toolkit</groupId>
                 <artifactId>codjo-gui-toolkit</artifactId>
-                <version>3.109</version>
+                <version>3.110-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.gui-toolkit</groupId>
                 <artifactId>codjo-gui-toolkit</artifactId>
                 <classifier>tests</classifier>
-                <version>3.109</version>
+                <version>3.110-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.xml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1081,12 +1081,12 @@
             <dependency>
                 <groupId>net.codjo.ads</groupId>
                 <artifactId>codjo-ads</artifactId>
-                <version>1.16</version>
+                <version>1.17-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.ads</groupId>
                 <artifactId>codjo-ads</artifactId>
-                <version>1.16</version>
+                <version>1.17-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
 


### PR DESCRIPTION
## For release  2.43

codjo-sandbox requests      
- Passwords changed for test accounts       https://github.com/codjo/codjo-ads/pull/7
- Remove unnecessary JDK6 hack in AbstractReadOnlyComponent   https://github.com/codjo/codjo-gui-toolkit/pull/11
## Downgrade javadoc plugin to 2.2
### Context

The maven `release:perform` goal fails while delivering multi-module projects that extends `codjo-pom-application`.
Maven's error message is that it cannot resolve the project dependencies :
### Description

for example while delivering magic 2.5 (wich can't be already in our local repository as we are building it for the first time):

```
   [INFO] ------------------------------------------------------------------------
   [ERROR] BUILD ERROR
   [INFO] ------------------------------------------------------------------------
   [INFO] Failed to resolve artifact.

   Missing:
   ----------
   1) com.agf.magic:magic-local-launcher:jar:2.5

     Try downloading the file manually from the project website.

     Then, install it using the command:
         mvn install:install-file -DgroupId=com.agf.magic -DartifactId=magic-local-launcher \
             -Dversion=2.5 -Dpackaging=jar -Dfile=/path/to/file

     Path to dependency:
       1) com.agf.magic:magic-server:jar:2.5
       2) com.agf.magic:magic-local-launcher:jar:2.5

   ----------
   1 required artifact is missing.

   for artifact:
     com.agf.magic:magic-server:jar:2.5
```

As a hack, man has to execute mvn clean install on target/checkout to help maven to solve dependencies.

Refering to cf http://jira.codehaus.org/browse/MRELEASE-271, it seems that the `maven-javadoc-plugin`
2.3 tries to run in fork mode on all submodules without taking into account dependency tree.
We downgraded the `maven-javadoc-plugin` to the 2.2 version.
