### PR TITLE
 For release 2.49 : rollback snapshot test and util

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -919,7 +919,7 @@
             <dependency>
                 <groupId>net.codjo.test</groupId>
                 <artifactId>codjo-test-common</artifactId>
-                <version>3.63-SNAPSHOT</version>
+                <version>3.62</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.release-test</groupId>
@@ -929,7 +929,7 @@
             <dependency>
                 <groupId>net.codjo.util</groupId>
                 <artifactId>codjo-util</artifactId>
-                <version>1.14-SNAPSHOT</version>
+                <version>1.13</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Switch libraries test and util from SNAPSHOT version to last stable version
