### PR TITLE
For release 2.56

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1485,6 +1485,33 @@
                 <artifactId>codjo-referential-server</artifactId>
                 <version>1.66</version>
             </dependency>
+            <dependency>
+                <groupId>net.codjo.data-process</groupId>
+                <artifactId>codjo-data-process-common</artifactId>
+                <version>2.75</version>
+            </dependency>
+            <dependency>
+                <groupId>net.codjo.data-process</groupId>
+                <artifactId>codjo-data-process-gui</artifactId>
+                <version>2.75</version>
+            </dependency>
+            <dependency>
+                <groupId>net.codjo.data-process</groupId>
+                <artifactId>codjo-data-process-server</artifactId>
+                <version>2.75</version>
+            </dependency>
+            <dependency>
+                <groupId>net.codjo.data-process</groupId>
+                <artifactId>codjo-data-process-server</artifactId>
+                <classifier>tests</classifier>
+                <version>2.75</version>
+            </dependency>
+            <dependency>
+                <groupId>net.codjo.data-process</groupId>
+                <artifactId>codjo-data-process-server</artifactId>
+                <classifier>datagen</classifier>				
+                <version>2.75</version>
+            </dependency>
 
             <dependency>
                 <groupId>net.codjo.globs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1208,45 +1208,45 @@
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-common</artifactId>
-                <version>6.56</version>
+                <version>6.57-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-common</artifactId>
-                <version>6.56</version>
+                <version>6.57-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-gui</artifactId>
-                <version>6.56</version>
+                <version>6.57-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.56</version>
+                <version>6.57-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.56</version>
+                <version>6.57-SNAPSHOT</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.56</version>
+                <version>6.57-SNAPSHOT</version>
                 <classifier>datagen-selector</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-batch</artifactId>
-                <version>6.56</version>
+                <version>6.57-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-release-test</artifactId>
-                <version>6.56</version>
+                <version>6.57-SNAPSHOT</version>
                 <classifier>tests</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -934,7 +934,7 @@
             <dependency>
                 <groupId>net.codjo.util</groupId>
                 <artifactId>codjo-util</artifactId>
-                <version>1.14</version>
+                <version>1.15-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -934,7 +934,7 @@
             <dependency>
                 <groupId>net.codjo.util</groupId>
                 <artifactId>codjo-util</artifactId>
-                <version>1.15-SNAPSHOT</version>
+                <version>1.14</version>
             </dependency>
 
             <dependency>
@@ -1208,45 +1208,45 @@
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-common</artifactId>
-                <version>6.57-SNAPSHOT</version>
+                <version>6.56</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-common</artifactId>
-                <version>6.57-SNAPSHOT</version>
+                <version>6.56</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-gui</artifactId>
-                <version>6.57-SNAPSHOT</version>
+                <version>6.56</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.57-SNAPSHOT</version>
+                <version>6.56</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.57-SNAPSHOT</version>
+                <version>6.56</version>
                 <classifier>datagen</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-server</artifactId>
-                <version>6.57-SNAPSHOT</version>
+                <version>6.56</version>
                 <classifier>datagen-selector</classifier>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-batch</artifactId>
-                <version>6.57-SNAPSHOT</version>
+                <version>6.56</version>
             </dependency>
             <dependency>
                 <groupId>net.codjo.broadcast</groupId>
                 <artifactId>codjo-broadcast-release-test</artifactId>
-                <version>6.57-SNAPSHOT</version>
+                <version>6.56</version>
                 <classifier>tests</classifier>
             </dependency>
 


### PR DESCRIPTION
## For release  2.56
## Add codjo-data-process library in dependency management
### Context

The `codjo-data-process` library has to be fully integrated in the framework in order to stop beeing an exception.
### Description

The following dependencies have been added to the dependency management:

```
            <dependency>
                <groupId>net.codjo.data-process</groupId>
                <artifactId>codjo-data-process-common</artifactId>
                <version>2.75</version>
            </dependency>
            <dependency>
                <groupId>net.codjo.data-process</groupId>
                <artifactId>codjo-data-process-gui</artifactId>
                <version>2.75</version>
            </dependency>
            <dependency>
                <groupId>net.codjo.data-process</groupId>
                <artifactId>codjo-data-process-server</artifactId>
                <version>2.75</version>
            </dependency>
            <dependency>
                <groupId>net.codjo.data-process</groupId>
                <artifactId>codjo-data-process-server</artifactId>
                <classifier>tests</classifier>
                <version>2.75</version>
            </dependency>
            <dependency>
                <groupId>net.codjo.data-process</groupId>
                <artifactId>codjo-data-process-server</artifactId>
                <classifier>datagen</classifier>                
                <version>2.75</version>
            </dependency>
```
